### PR TITLE
Fixed property name and type in tables

### DIFF
--- a/templates/properties.njk
+++ b/templates/properties.njk
@@ -1,6 +1,6 @@
 | Name | Type | Description | Required | Pattern |
 |:-----|:----:|:------------|:--------:|--------:|
-{% for prop in properties %}| {{ prop.displayName }} | {{ prop.type }} | {{ prop.description }} | {{ prop.required }} | {{ prop.pattern }} |
+{% for prop in properties %}| {{ prop.key }} | {{ prop.type if prop.key === prop.displayName else prop.displayName }} | {{ prop.description }} | {{ prop.required }} | {{ prop.pattern }} |
 {% endfor %}
 
 {% for prop in properties %}


### PR DESCRIPTION
Fix for #3.

It would appear that displayName is not reliable as the name for a field, but the `key` is.

Also prop.type refers to the base type of the given type, rather than the defined type itself. In those cases, the displayName is actually the correct type for the property.

Also, i'm not too familiar with how the tests work, so i would appreciate help on updating those if need be.

Output with the same raml from the issue:

# Type name bug example API documentation version v1

---

## /test

### /test

#### **GET**:
Test of type names.

### Response code: 200

#### application/json (application/json) 

##### *application/json*:
| Name | Type | Description | Required | Pattern |
|:-----|:----:|:------------|:--------:|--------:|
| thing | MyModel | things thing | true |  |
| transactionId | string | Unique Identification value for the transaction. | true |  |

| Name | Type | Description | Required | Pattern |
|:-----|:----:|:------------|:--------:|--------:|
| field1 | integer |  | true |  |
| field2 | string |  | true |  |
| field3 | boolean |  | true |  |

---

