### PR TITLE
Fixed showing array items properties

### DIFF
--- a/templates/properties.njk
+++ b/templates/properties.njk
@@ -1,8 +1,16 @@
 | Name | Type | Description | Required | Pattern |
 |:-----|:----:|:------------|:--------:|--------:|
-{% for prop in properties %}| {{ prop.displayName }} | {{ prop.type }} | {{ prop.description }} | {{ prop.required }} | {{ prop.pattern }} |
+{% for prop in properties %}| {{ prop.displayName }} | {{ prop.items.displayName if prop.type === "array" }} {{ prop.type }} | {{ prop.description }} | {{ prop.required }} | {{ prop.pattern }} |
 {% endfor %}
 
 {% for prop in properties %}
-{% if prop.properties %}{% set properties=prop.properties %}{% include "./properties.njk" %}{% endif %}
+{% if prop.properties %}
+{{ prop.displayName }}:
+
+{% set properties=prop.properties %}{% include "./properties.njk" %}
+{% elif prop.items and prop.items.properties %}
+{{ prop.items.displayName }}:
+
+{% set properties=prop.items.properties %}{% include "./properties.njk" %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
Fix for #2.

Heres the output for the same raml from the issue:

# Array bug example API documentation version v1

---

## /test

### /test

#### **GET**:
Test of array types.

### Response code: 200

#### application/json (application/json) 

##### *application/json*:
| Name | Type | Description | Required | Pattern |
|:-----|:----:|:------------|:--------:|--------:|
| data | MyModel array | MyModel array | true |  |
| transactionId |  string | Unique Identification value for the transaction. | true |  |

MyModel:

| Name | Type | Description | Required | Pattern |
|:-----|:----:|:------------|:--------:|--------:|
| field1 |  integer |  | true |  |
| field2 |  string |  | true |  |
| field3 |  boolean |  | true |  |

---

