### PR TITLE
Fix #10 by \n and indent.

### DIFF
--- a/templates/toc.njk
+++ b/templates/toc.njk
@@ -1,1 +1,2 @@
-{% if resource.methods %}* [{{ resource.parentUrl + resource.relativeUri }}](#{{ (resource.parentUrl + resource.relativeUri) | lower() | replace('/', '') | replace('{', '') | replace('}', '') }}){% endif %}{% for resource in resource.resources %}{% include "./toc.njk" %}{% endfor %}
+{% if resource.methods %}* [{{ resource.parentUrl + resource.relativeUri }}](#{{ (resource.parentUrl + resource.relativeUri) | lower() | replace('/', '') | replace('{', '') | replace('}', '') }}){% endif %}
+  {% for resource in resource.resources %}{% include "./toc.njk" %}{% endfor %}


### PR DESCRIPTION
When list items are generated as part of a list of URIs which are subpaths, they end up on the same line instead of sequential, ie, when rendering:

/clusters:
  get:
  post:
  /{cluster_id}:
    get:
    put:
You'll end up with this:

/clusters * /clusters/{cluster_id}
instead of

/clusters
/clusters/{cluster_id}