### PR TITLE
Fixed table of content not always separated by a new line

### DIFF
--- a/templates/toc.njk
+++ b/templates/toc.njk
@@ -1,1 +1,2 @@
-{% if resource.methods %}* [{{ resource.parentUrl + resource.relativeUri }}](#{{ (resource.parentUrl + resource.relativeUri) | lower() | replace('/', '') | replace('{', '') | replace('}', '') }}){% endif %}{% for resource in resource.resources %}{% include "./toc.njk" %}{% endfor %}
+{% if resource.methods %}
+* [{{ resource.parentUrl + resource.relativeUri }}](#{{ (resource.parentUrl + resource.relativeUri) | lower() | replace('/', '') | replace('{', '') | replace('}', '') }}){% endif %}{% for resource in resource.resources %}{% include "./toc.njk" %}{% endfor %}


### PR DESCRIPTION
the toc would sometimes appear like that:

```
* [/route1](#route1)* [/route2](#route2)
* [/route3](#route3)
```

now it's:

```
* [/route1](#route1)
* [/route2](#route2)
* [/route3](#route3)
```
