### PR TITLE
Removed properties table if empty

### DIFF
--- a/templates/schemas.njk
+++ b/templates/schemas.njk
@@ -11,7 +11,7 @@
 ##### List of *{{ schema.items.displayName }}*:
 
 {% set properties=schema.items.properties %}{% include "./properties.njk" %}
-{% else %}
+{% elif schema.properties %}
 ##### *{{ schema.displayName }}*:
 {% set properties=schema.properties %}{% include "./properties.njk" %}
 {% endif %}


### PR DESCRIPTION
When I had no properties, the table was not rendered properly:

![Screen Shot 2019-10-25 at 11 23 51 AM](https://user-images.githubusercontent.com/1644534/67583738-2e545580-f71a-11e9-8ddf-946b34ff9291.png)
